### PR TITLE
Fix #145 - Zoom out the default map

### DIFF
--- a/modernism/static/_js/miaMap.js
+++ b/modernism/static/_js/miaMap.js
@@ -1,4 +1,13 @@
-const zoomLevel = document.documentElement.clientWidth < 970 ? 4 : 4; // leave a condition here in case of future improvements
+let zoomLevel;
+
+if (document.documentElement.clientWidth >= 1400) {
+    // Large screens
+    zoomLevel = 5;
+} else {
+    // small devices and laptops
+    zoomLevel = 4
+}
+
 const mapMia = L.map('mapMia').setView([51.339642, 12.374462], zoomLevel);
 const markers = L.markerClusterGroup({ maxClusterRadius: 20 });
 

--- a/modernism/static/_js/miaMap.js
+++ b/modernism/static/_js/miaMap.js
@@ -1,4 +1,4 @@
-const zoomLevel = document.documentElement.clientWidth < 970 ? 4 : 6;
+const zoomLevel = document.documentElement.clientWidth < 970 ? 4 : 4; // leave a condition here in case of future improvements
 const mapMia = L.map('mapMia').setView([51.339642, 12.374462], zoomLevel);
 const markers = L.markerClusterGroup({ maxClusterRadius: 20 });
 


### PR DESCRIPTION
Fix for issue https://github.com/Modernism-in-Architecture/modernism/issues/145

The new zoom level allows us to display all objects on the map even on small monitors